### PR TITLE
fixed: 'TypeError: mkdir() takes no keyword arguments' 

### DIFF
--- a/juniper-gui/lib/juniper_ui.py
+++ b/juniper-gui/lib/juniper_ui.py
@@ -284,7 +284,7 @@ class MainWindow(QtGui.QMainWindow):
 
     def loadConfig(self):
         if not os.path.exists(os.path.dirname(self.configFile)):
-            os.mkdir(os.path.dirname(self.configFile), mode=0755)
+            os.mkdir(os.path.dirname(self.configFile), 0755)
 
         defaults = {
             'vpnHost': 'vpn.example.com',


### PR DESCRIPTION
fixed: 'TypeError: mkdir() takes no keyword arguments'  when jgui is launched.

apparently mkdir() is on of the Python / C API functions which does not have named arguments.
http://stackoverflow.com/questions/24463202/typeerror-get-takes-no-keyword-arguments#24463222